### PR TITLE
Add support for exporting deep-equal as petal module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 (function( factory ) {
   if (typeof define !== 'undefined' && define.amd) {
     define([], factory);
-  } else if (typeof define !== 'undefined' && && define.petal) {
+  } else if (typeof define !== 'undefined' && define.petal) {
     define(['deep-equal'], [], factory);
   } else if (typeof module !== 'undefined' && module.exports) {
     module.exports = factory();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 (function( factory ) {
   if (typeof define !== 'undefined' && define.amd) {
     define([], factory);
+  } else if (typeof define !== 'undefined' && && define.petal) {
+    define(['deep-equal'], [], factory);
   } else if (typeof module !== 'undefined' && module.exports) {
     module.exports = factory();
   } else {


### PR DESCRIPTION
This changes aims to add support for exporting deep-equal as a petal module when used from within a ember-cli project. This allows you to refer deep-equal module in es6 format like,

import deepEqual from 'deep-equal';
